### PR TITLE
Improvements around battlerage usage

### DIFF
--- a/script.lua
+++ b/script.lua
@@ -1108,12 +1108,12 @@ keneanung.bashing.vitalsChangeRecord = function()
 		end
 	end
 
-	keneanung.bashing.battlerage[keneanung.bashing.configuration.rageStrat](rage)
+	keneanung.bashing.battlerage[keneanung.bashing.configuration.rageStrat](rage, battlerageSkills)
 
 end
 
 keneanung.bashing.buttonActionsCallback = function()
-	keneanung.bashing.battlerage[keneanung.bashing.configuration.rageStrat](rage)
+	keneanung.bashing.battlerage[keneanung.bashing.configuration.rageStrat](rage, battlerageSkills)
 end
 
 keneanung.bashing.charStatusCallback = function()

--- a/script.lua
+++ b/script.lua
@@ -1429,7 +1429,7 @@ keneanung.bashing.handleSkillInfo = function()
 
 	local cooldown = tonumber(skillInfo.info:match("(%d+\.%d+) seconds"))
 	local rage = tonumber(skillInfo.info:match("(%d+) rage"))
-	local command = skillInfo.info:match("\n(.+<target>.-)\n"):gsub("<target>", "%%d")
+	local command = skillInfo.info:match("Syntax:\n(.-)\n"):gsub("<target>", "%%d")
 	local affliction = skillInfo.info:match("Gives denizen affliction: (%w+)")
 	local affsUsed = {skillInfo.info:match("Uses denizen afflictions: (%w+) or (%w+)")}
 	local skillKnown = skillInfo.info:find("*** You have not yet learned this ability ***", 1, true) == nil


### PR DESCRIPTION
The first commit will give the parsed battlerage skills to the called rage strategy. This removes the need to code the information into plugins in some form.

The second fixes battlerage skill recognition for knights, who have a self targeting skill. This does not have the <target> part in it.