### PR TITLE
Defer first call of setAlias

### DIFF
--- a/script.lua
+++ b/script.lua
@@ -1268,8 +1268,6 @@ keneanung.bashing.login = function()
 	gmod.enableModule("keneanung.bashing", "IRE.Display")
 	sendGMCP([[Core.Supports.Add ["IRE.Display 3"] ]])   -- register the GMCP module independently from gmod.
 	sendGMCP([[Char.Skills.Get {"group":"battlerage"}]])
-	keneanung.bashing.setAlias("attackcommand")
-	keneanung.bashing.setAlias("razecommand")
 	local system = keneanung.bashing.systems[keneanung.bashing.configuration.system]
 	system.setup()
 	sessionGains.gold = 0


### PR DESCRIPTION
Since the class is not yet known on login and it gets called when the class is
recieved anyways, we don't call the function on login.

Signed-off-by: keneanung <keneanung@googlemail.com>