### PR TITLE
Consider the content "none" of the variable "target" a non-target

### DIFF
--- a/script.lua
+++ b/script.lua
@@ -1303,11 +1303,13 @@ keneanung.bashing.setTarget = function()
 		local tar
 		local targetSet = false
 
-		if target ~= nil and target ~='' then
+		if target ~= nil and target ~='' and target:lower() ~= "none" then
 			tar = target
 		elseif gmcp.Char.Status.target ~= "None" then
 			tar = gmcp.Char.Status.target
 		end
+
+		debugMessage("set tar", tar)
 
 		if tar ~= nil then
 


### PR DESCRIPTION
Some targetting systems/targetters/stuff don't sure the empty string, but instead "none" to clear the target. That's why ignore them as fallback target as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/achaeabashingscript/bashing/44)
<!-- Reviewable:end -->
