### PR TITLE
Group bashing

### DIFF
--- a/Bashing.xml
+++ b/Bashing.xml
@@ -286,7 +286,7 @@ disableAlias(&quot;import from Guhem&quot;)</script>
                     <regex>^kconfig bashing manual$</regex>
                 </Alias>
                 <Alias isActive="yes" isFolder="no">
-                    <name>set flee threshold</name>
+                    <name>set wait for target</name>
                     <script>keneanung.bashing.setWaitForTarget(matches[2])</script>
                     <command></command>
                     <packageName></packageName>

--- a/Bashing.xml
+++ b/Bashing.xml
@@ -278,6 +278,13 @@ disableAlias(&quot;import from Guhem&quot;)</script>
                     <packageName></packageName>
                     <regex>^kconfig bashing guhemimport$</regex>
                 </Alias>
+                <Alias isActive="yes" isFolder="no">
+                    <name>toggle manual targetting</name>
+                    <script>keneanung.bashing.toggle('manualTargetting', 'Manual targetting')</script>
+                    <command></command>
+                    <packageName></packageName>
+                    <regex>^kconfig bashing manual$</regex>
+                </Alias>
             </AliasGroup>
         </AliasGroup>
     </AliasPackage>

--- a/Bashing.xml
+++ b/Bashing.xml
@@ -285,6 +285,13 @@ disableAlias(&quot;import from Guhem&quot;)</script>
                     <packageName></packageName>
                     <regex>^kconfig bashing manual$</regex>
                 </Alias>
+                <Alias isActive="yes" isFolder="no">
+                    <name>set flee threshold</name>
+                    <script>keneanung.bashing.setWaitForTarget(matches[2])</script>
+                    <command></command>
+                    <packageName></packageName>
+                    <regex>^kconfig bashing waitfortarget (\d+)$</regex>
+                </Alias>
             </AliasGroup>
         </AliasGroup>
     </AliasPackage>

--- a/Bashing.xml
+++ b/Bashing.xml
@@ -209,6 +209,27 @@
                     <packageName></packageName>
                     <regex>^kconfig bashing targetloyals$</regex>
                 </Alias>
+                <Alias isActive="yes" isFolder="no">
+                    <name>show gains</name>
+                    <script>keneanung.bashing.printGains(matches[2])</script>
+                    <command></command>
+                    <packageName></packageName>
+                    <regex>^kshow gains (lifetime|session|trip)</regex>
+                </Alias>
+                <Alias isActive="yes" isFolder="no">
+                    <name>start a new hunting trip</name>
+                    <script>keneanung.bashing.startHuntingTrip()</script>
+                    <command></command>
+                    <packageName></packageName>
+                    <regex>^ktrip start$</regex>
+                </Alias>
+                <Alias isActive="yes" isFolder="no">
+                    <name>stop the current hunting trip</name>
+                    <script>keneanung.bashing.stopHuntingTrip()</script>
+                    <command></command>
+                    <packageName></packageName>
+                    <regex>^ktrip stop$</regex>
+                </Alias>
             </AliasGroup>
         </AliasGroup>
     </AliasPackage>
@@ -353,6 +374,14 @@ use &quot;flee &lt;direction&gt;&quot; to set a new direction.
                         <script>--This registers our Char.Status callback. Do not remove!</script>
                         <eventHandlerList>
                             <string>gmcp.Char.Status</string>
+                        </eventHandlerList>
+                    </Script>
+                    <Script isActive="yes" isFolder="no">
+                        <name>keneanung.bashing.save</name>
+                        <packageName></packageName>
+                        <script>--This registers our sysExitEvent callback. Do not remove!</script>
+                        <eventHandlerList>
+                            <string>sysExitEvent</string>
                         </eventHandlerList>
                     </Script>
                 </ScriptGroup>

--- a/README.md
+++ b/README.md
@@ -258,7 +258,12 @@ me and I'm sure we can work something out.
 Money
 -----
 
+*This is valid as long as I am the sole maintainer of the project. As soon as other chime in, I will remove the two items
+below for fairness reasons.*
+
 You can send bitcoins to this address: 1M6DVCYeGmWN7yR3no3XjeZq3jrydKhYe7
+
+I also have an Amazon wishlist: https://www.amazon.de/gp/registry/wishlist/20AAS3W9RZLAF
 
 Credits or other in game stuff
 ------------------------------

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The Basher has a generic support for group bashing built in. However since group
 communication is very different between different groups, there are no triggers
 or party/group calls or custom battlerage strategies included.
 
-This document will list some general things that may be useful to have or do 
+This document will list some general things that may be useful to have or do
 when hunting with a group.
 
 ### Targetting ###
@@ -132,8 +132,9 @@ leader to the list.
 To activate that mode, use the alias `kconfig bashing manual` to toggle manual
 targetting.
 
-# TODO #
-check alias above and add a manual target function. Document it here.
+When in manual targetting mode, you can use the
+`keneanung.bashing.manuallyTarget()` function to change the target to a denizen
+of your choice by giving it a denizen ID to switch to.
 
 ### Battlerage strategies ###
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ When in manual targetting mode, you can use the
 `keneanung.bashing.manuallyTarget()` function to change the target to a denizen
 of your choice by giving it a denizen ID to switch to.
 
+If your current target leaves, it will wait for a time (default 2 seconds), for
+a new target to continue attacking. If a new target is set within that timeframe
+, the basher will continue attacking. You can customize the time with the
+command `kconfig bashing waitfortarget <numberofseconds>`.
+
 ### Battlerage strategies ###
 
 Depending on the class and composition of the group, it might be useful to
@@ -161,7 +166,7 @@ Configuration
 The current configuration can be shown with the alias `kconfig bashing`. All items in red are clickable and will either
 toggle the item or set the alias to the command line, so you only need to add the add the value you want to set.
 
-The basher stores one set of settings for each class, so remember to tweak your
+The basher stores certain settings for each class, so remember to tweak your
 configuration when switching to a new one!
 
 ### Warn and flee thresholds ###

--- a/script.lua
+++ b/script.lua
@@ -138,12 +138,19 @@ keneanung.bashing.systems.svo = {
 	
 	setup = function()
 		send = function(command, echoback)
+			debugMessage("send got called", {command = command, echoback = echoback })
+			local useAlias = false
 			if command == "keneanungki" then
 				command = keneanung.bashing.configuration.attackcommand
+				useAlias = true
 			elseif command == "keneanungra" then
 				command = keneanung.bashing.configuration.razecommand
+				useAlias = true
 			end
-			command = command:gsub("&tar", keneanung.bashing.targetList[keneanung.bashing.attacking].id)
+			if keneanung.bashing.attacking > 0 and useAlias then
+				command = command:gsub("&tar", keneanung.bashing.targetList[keneanung.bashing.attacking].id)
+			end
+
 			local commands = command:split("/")
 			for _, part in ipairs(commands) do
 				svo.sendc(part, echoback)
@@ -713,7 +720,7 @@ keneanung.bashing.toggle = function(what, print)
 end
 
 keneanung.bashing.shielded = function(what)
-	if what == keneanung.bashing.targetList[keneanung.bashing.attacking].name then
+	if keneanung.bashing.attacking > 0 and what == keneanung.bashing.targetList[keneanung.bashing.attacking].name then
 		local system = keneanung.bashing.systems[keneanung.bashing.configuration.system]
 		system.handleShield()
 	end

--- a/script.lua
+++ b/script.lua
@@ -1690,14 +1690,14 @@ keneanung.bashing.getDenizenName = function(id)
 end
 
 keneanung.bashing.getTargetObject = function(id)
-  if not tonumber(id) then
-    kecho("You are trying to access the denizen with ID <red>" .. id .. "<reset> which is not a numerical ID.")
-    return
-  end
-	local result = directTargetAccess[id]
+	if not tonumber(id) then
+		kecho("You are trying to access the denizen with ID <red>" .. id .. "<reset> which is not a numerical ID.")
+		return
+	end
+	local result = directTargetAccess[tostring(id)]
 	if not result then
 		result = { id = id, name = keneanung.bashing.getDenizenName(id), affs = {} }
-		directTargetAccess[id] = result
+		directTargetAccess[tostring(id)] = result
 	end
 	return result
 end
@@ -1718,13 +1718,13 @@ keneanung.bashing.guhemImport = function()
 end
 
 keneanung.bashing.manuallyTarget = function(what)
-  if not keneanung.bashing.configuration.manualTargetting then return end
-  local item = keneanung.bashing.getTargetObject(what)
-  if not item then return end
-  keneanung.bashing.targetList = { item }
-  sendGMCP('IRE.Target.Set "' .. item.id .. '"')
-  raiseEvent("keneanung.bashing.targetList.changed")
-  raiseEvent("keneanung.bashing.targetList.firstChanged", keneanung.bashing.targetList[1].id)
+	if not keneanung.bashing.configuration.manualTargetting then return end
+	local item = keneanung.bashing.getTargetObject(what)
+	if not item then return end
+	keneanung.bashing.targetList = { item }
+	sendGMCP('IRE.Target.Set "' .. item.id .. '"')
+	raiseEvent("keneanung.bashing.targetList.changed")
+	raiseEvent("keneanung.bashing.targetList.firstChanged", keneanung.bashing.targetList[1].id)
 end
 
 

--- a/script.lua
+++ b/script.lua
@@ -744,14 +744,6 @@ keneanung.bashing.showConfig = function()
 end
 
 keneanung.bashing.toggle = function(what, print)
-<<<<<<< HEAD
-	if what == "autoraze" or what == "autorageraze" then
-		keneanung.bashing.configuration[class][what] = not keneanung.bashing.configuration[class][what]
-	else
-		keneanung.bashing.configuration[what] = not keneanung.bashing.configuration[what]
-	end
-	kecho(print .. " <red>" .. (keneanung.bashing.configuration[what] and "enabled" or "disabled") .. "\n" )
-=======
 	local toPrint
 	if what == "autoraze" or what == "autorageraze" then
 		keneanung.bashing.configuration[class][what] = not keneanung.bashing.configuration[class][what]
@@ -761,7 +753,6 @@ keneanung.bashing.toggle = function(what, print)
 		toPrint = keneanung.bashing.configuration[what] and "enabled" or "disabled"
 	end
 	kecho(print .. " <red>" .. toPrint .. "\n" )
->>>>>>> master
 	keneanung.bashing.save()
 end
 
@@ -1499,7 +1490,7 @@ keneanung.bashing.handleSkillInfo = function()
 
 	local cooldown = tonumber(skillInfo.info:match("(%d+\.%d+) seconds"))
 	local rage = tonumber(skillInfo.info:match("(%d+) rage"))
-	local command = skillInfo.info:match("Syntax:\n(.-)\n"):gsub("<target>", "%%d")
+	local command = skillInfo.info:match("Syntax:\n(.-)\n"):gsub("<target>", "%%s")
 	local affliction = skillInfo.info:match("Gives denizen affliction: (%w+)")
 	local affsUsed = {skillInfo.info:match("Uses denizen afflictions: (%w+) or (%w+)")}
 	for ind, aff in ipairs(affsUsed) do

--- a/script.lua
+++ b/script.lua
@@ -38,6 +38,10 @@ local afflictions = {
 		colour = "black:yellow",
 		timer = 4
 	},
+	amnesia = {
+		colour = "LightGrey",
+		timer = 5
+	},
 }
 local sessionGains = { }
 local tripGains = { gold = 0, experience = 0 }

--- a/script.lua
+++ b/script.lua
@@ -1225,6 +1225,9 @@ keneanung.bashing.login = function()
 	system.setup()
 	sessionGains.gold = 0
 	sessionGains.experience = 0
+	lastGoldChange = nil
+	lastXpChange = nil
+	lastGold = nil
 end
 
 keneanung.bashing.setAlias = function(command)

--- a/script.lua
+++ b/script.lua
@@ -821,20 +821,28 @@ local roomItemCallbackWorker = function(event)
 
 	if(event == "gmcp.Char.Items.List") then
 
+		--restore targets we had when we were in the room last
 		local storedTargets = roomTargetStore[gmcp.Room.Info.num]
 
 		if storedTargets then
 			keneanung.bashing.targetList = storedTargets.targetList
-			keneanung.bashing.attacking = storedTargets.attacked
 		end
 
 		local targetList = {}
 		-- make sure our targets stay at the same place!
 		for index, targ in ipairs(keneanung.bashing.targetList) do
-			if index > keneanung.bashing.attacking then
-				break
+			-- search if that target possibly left the room
+			local found = false
+			for _, item in ipairs(gmcp.Char.Items.List.items) do
+				if item.id == targ.id then
+					found = true
+					break
+				end
 			end
-			targetList[#targetList + 1] = targ
+			-- still there? Add it in the old place
+			if found then
+				targetList[#targetList + 1] = targ
+			end
 		end
 		keneanung.bashing.targetList = targetList
 		keneanung.bashing.room = {}
@@ -1036,7 +1044,6 @@ keneanung.bashing.roomMessageCallback = function()
 
 	roomTargetStore[keneanung.bashing.lastRoom] = {
 		targetList = keneanung.bashing.targetList,
-		attacked = keneanung.bashing.attacking
 	}
 
 	keneanung.bashing.damage = 0

--- a/script.lua
+++ b/script.lua
@@ -1410,7 +1410,7 @@ keneanung.bashing.setTarget = function()
 			return
 		end
 	end
-	if keneanung.bashing.attacking == 0 or keneanung.bashing.targetList[keneanung.bashing.attacking].id ~= gmcp.Char.Status.target then
+	if keneanung.bashing.attacking == 0 or keneanung.bashing.targetList[keneanung.bashing.attacking].id ~= gmcp.IRE.Target.Info.id then
 		keneanung.bashing.attacking = keneanung.bashing.attacking + 1
 	end
 	debugMessage("setting target", keneanung.bashing.targetList[keneanung.bashing.attacking])

--- a/script.lua
+++ b/script.lua
@@ -1690,6 +1690,10 @@ keneanung.bashing.getDenizenName = function(id)
 end
 
 keneanung.bashing.getTargetObject = function(id)
+  if not tonumber(id) then
+    kecho("You are trying to access the denizen with ID <red>" .. id .. "<reset> which is not a numerical ID.")
+    return
+  end
 	local result = directTargetAccess[id]
 	if not result then
 		result = { id = id, name = keneanung.bashing.getDenizenName(id), affs = {} }
@@ -1711,6 +1715,16 @@ keneanung.bashing.guhemImport = function()
 			end
 		end
 	end	
+end
+
+keneanung.bashing.manuallyTarget = function(what)
+  if not keneanung.bashing.configuration.manualTargetting then return end
+  local item = keneanung.bashing.getTargetObject(what)
+  if not item then return end
+  keneanung.bashing.targetList = { item }
+  sendGMCP('IRE.Target.Set "' .. item.id .. '"')
+  raiseEvent("keneanung.bashing.targetList.changed")
+  raiseEvent("keneanung.bashing.targetList.firstChanged", keneanung.bashing.targetList[1].id)
 end
 
 

--- a/script.lua
+++ b/script.lua
@@ -1381,10 +1381,10 @@ keneanung.bashing.addDenizenAffliction = function(denizen, affliction, own)
 		return
 	end
 
-	local isTarget = (keneanung.bashing.targetList[keneanung.bashing.attacking] == denizenObject)
+	local isTarget = (keneanung.bashing.targetList[keneanung.bashing.attacking].id == denizenObject.id)
 
 	denizenObject.affs[affliction] = tempTimer(affObject.timer,
-		string.format("keneanung.bashing.removeDenizenAffliction('%s', '%s', %s)", denizenObject.id, affliction, own and "true" or false))
+		string.format("keneanung.bashing.removeDenizenAffliction('%s', '%s', %s)", denizenObject.id, affliction, own and "true" or "false"))
 
 	kecho(string.format("<%s>%s%s<reset> <green>gained<reset> <%s>%s<reset>", isTarget and "OrangeRed" or "yellow",
 		denizenObject.name, isTarget and " (your target)" or "", affObject.colour, affliction))
@@ -1413,7 +1413,7 @@ keneanung.bashing.removeDenizenAffliction = function(denizen, affliction, own)
 		return
 	end
 
-	local isTarget = (keneanung.bashing.targetList[keneanung.bashing.attacking] == denizenObject)
+	local isTarget = (keneanung.bashing.targetList[keneanung.bashing.attacking].id == denizenObject.id)
 
 	killTimer(denizenObject.affs[affliction])
 	kecho(string.format("<%s>%s%s<reset> <red>lost<reset> <%s>%s<reset>",
@@ -1430,8 +1430,7 @@ keneanung.bashing.getAfflictions = function(denizen)
 	local denizenObject = directTargetAccess[denizen]
 	debugMessage("associated denizen object from direct access", denizenObject)
 	if not denizenObject then
-		kecho("Denizen '<red>" .. denizen .. "<reset>' not in list of targets.")
-		return
+		return {}
 	end
 
 	local ret = {}
@@ -1448,8 +1447,7 @@ keneanung.bashing.hasAffliction = function(denizen, affliction)
 	local denizenObject = directTargetAccess[denizen]
 	debugMessage("associated denizen object from direct access", denizenObject)
 	if not denizenObject then
-		kecho("Denizen '<red>" .. denizen .. "<reset>' not in list of targets.")
-		return
+		return false
 	end
 
 	return denizenObject.affs[affliction] ~= nil

--- a/script.lua
+++ b/script.lua
@@ -39,6 +39,8 @@ local afflictions = {
 		timer = 4
 	},
 }
+local sessionGains = { }
+local tripGains = { gold = 0, experience = 0 }
 
 local requestSkillDetails = {}
 local battlerageSkills = {}
@@ -46,6 +48,9 @@ local rage = 0
 
 local race = ""
 local class = ""
+local lastGoldChange
+local lastGold
+local lastXp
 
 local roomTargetStore = {}
 
@@ -76,6 +81,7 @@ keneanung.bashing.configuration.system = "auto"
 keneanung.bashing.configuration.filesToLoad = {}
 keneanung.bashing.configuration.rageStrat = "simple"
 keneanung.bashing.configuration.targetLoyals = false
+keneanung.bashing.configuration.lifetimeGains = { gold = 0, experience = 0 }
 
 local debugMessage = function(message, content)
 	if not debugEnabled then return end
@@ -1113,6 +1119,44 @@ keneanung.bashing.charStatusCallback = function()
 	if somethingChanged then
 		sendGMCP([[Char.Skills.Get {"group":"battlerage"}]]) -- rerequest battlerage abilities
 	end
+
+	debugMessage("Going to calculate gold gains", { lastGoldChange = lastGoldChange, lastGold = lastGold } )
+
+	local goldNumber = tonumber(gmcp.Char.Status.gold)
+	local goldChange = goldNumber - (lastGold or 0)
+
+	debugMessage("Got new gold numbers", { goldChange = goldChange, goldNumber = goldNumber } )
+
+	local lifetimeGains = keneanung.bashing.configuration.lifetimeGains
+
+	if lastGoldChange ~= nil then -- On login, skip this
+
+		if goldChange + lastGoldChange ~= 0 and goldChange > 0 then	-- We only want to count
+										-- real changes (not
+			sessionGains.gold = sessionGains.gold + goldChange	-- taking from pack) and
+			tripGains.gold = tripGains.gold + goldChange		-- gold gains.
+			lifetimeGains.gold = lifetimeGains.gold + goldChange
+
+		end
+
+	end
+
+	lastGoldChange = goldChange
+	lastGold = goldNumber
+
+	local newXp = gmcp.Char.Status.level:match("^(%d+)") * 100 + gmcp.Char.Status.xp:match("(.+)%%")
+
+	debugMessage("Calculating experience gain", { lastXp = lastXp, newXp = newXp })
+
+	if lastXp ~= nil then
+
+		sessionGains.experience = sessionGains.experience + newXp - lastXp
+		tripGains.experience = tripGains.experience + newXp - lastXp
+		lifetimeGains.experience = lifetimeGains.experience + newXp - lastXp
+
+	end
+
+	lastXp = newXp
 end
 
 keneanung.bashing.setCommand = function(command, what)
@@ -1179,6 +1223,8 @@ keneanung.bashing.login = function()
 	keneanung.bashing.setAlias("razecommand")
 	local system = keneanung.bashing.systems[keneanung.bashing.configuration.system]
 	system.setup()
+	sessionGains.gold = 0
+	sessionGains.experience = 0
 end
 
 keneanung.bashing.setAlias = function(command)
@@ -1403,6 +1449,49 @@ keneanung.bashing.rageAvailable = function(ability)
 		end
 	end
 	return false
+end
+
+keneanung.bashing.printGains = function(which)
+	local gainsTable
+	if which == "lifetime" then
+		gainsTable = keneanung.bashing.configuration.lifetimeGains
+	elseif which == "session" then
+		gainsTable = sessionGains
+	elseif which == "trip" then
+		gainsTable = tripGains
+	else
+		kecho(string.format("Gains for the timespan '<red>%s<reset>' are not tracked.", which))
+		return
+	end
+
+	local levels, percent = math.modf(gainsTable.experience / 100)
+	percent = percent * 100
+	kecho(string.format("You gained <red>%d<reset> levels, <red>%.1f%%<reset> towards the next level and <red>%d<reset> gold during the period '<red>%s<reset>'.", levels, percent, gainsTable.gold, which))
+	if gainsTable.stopwatch then
+		local time = getStopWatchTime(gainsTable.stopwatch)
+		kecho(string.format("The period was <red>%d<reset>h <red>%d<reset>min and <red>%.3f<reset> sec long.", math.floor(time / 3600), math.floor( math.mod(time, 3600) / 60), math.mod(time, 60)))
+	end
+end
+
+keneanung.bashing.startHuntingTrip = function()
+	if not tripGains.stopwatch then
+		tripGains = { gold = 0, experience = 0, stopwatch = createStopWatch() }
+		startStopWatch(tripGains.stopwatch)
+		kecho("Started new hunting trip. Enjoy and be careful.")
+	else
+		kecho("Ugh- Finish the running trip before starting a new one?")
+	end
+end
+
+keneanung.bashing.stopHuntingTrip = function()
+	if tripGains.stopwatch then
+		kecho("Stopped hunting trip. I hope you had fun.")
+		keneanung.bashing.printGains("trip")
+		stopStopWatch(tripGains.stopwatch)
+		tripGains.stopwatch = nil
+	else
+		kecho("You are not hunting or didn't tell me you did. Can't stop anything.")
+	end
 end
 
 keneanung.bashing.load()


### PR DESCRIPTION
This PR aims at improving group bashing. It allows for manual setting of targets, improves handling of denizen affliction and can raise events when using a denizen affliction.

Since all of those actions are the result of communication, which happens differently in every group, there are no builtin triggers or party calls. I am considering publishing the suit of rage strategies, triggers and calls in the plugin repository, so people have an idea how to use these new functions.

TODO: documentation update.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/achaeabashingscript/bashing/45)

<!-- Reviewable:end -->
