### PR TITLE
Add callback for when queue is cleared

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ The `keneanung.bashing.targetList.firstChanged` event is raised whenever the fir
 means a new target is used. This event also gives the new target as argument to the event handlers. To access the first item
 of the target list directly, you can access `keneanung.bashing.targetList[1]`.
 
+The `keneanung.bashing.targetList.cleared` event ijs raised whenever an item from the target list is removed, leaving the target list empty.
+
 The `keneanung.bashing.afflictionGained` event is raised, whenever a new
 battlerage affliction is registered, where the user is the source. This event can be used
 to relay the information to party or group chats without a need for triggers.

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ The `keneanung.bashing.targetList.firstChanged` event is raised whenever the fir
 means a new target is used. This event also gives the new target as argument to the event handlers. To access the first item
 of the target list directly, you can access `keneanung.bashing.targetList[1]`.
 
-The `keneanung.bashing.targetList.cleared` event ijs raised whenever an item from the target list is removed, leaving the target list empty.
+The `keneanung.bashing.targetList.cleared` event is raised whenever an item from the target list is removed and it leaves the target list empty.
 
 The `keneanung.bashing.afflictionGained` event is raised, whenever a new
 battlerage affliction is registered, where the user is the source. This event can be used

--- a/script.lua
+++ b/script.lua
@@ -1154,7 +1154,11 @@ keneanung.bashing.removeTarget = function(item)
 	end
 
 	keneanung.bashing.targetList = targets
-
+	
+	if #targets == 0 then
+		raiseEvent("keneanung.bashing.targetList.cleared")
+	end
+	
 end
 
 keneanung.bashing.prioListChangedCallback = function()


### PR DESCRIPTION
I'm working on adding gold/shard pickup (since it doesn't seem like it's in there), and this callback is part of it. When the queue is cleared, it should fire off this event.

I understand it can fire when a mob enters, no attacking is done, and then they leave. That seems like a acceptable situation for me. Mostly I was hoping to tie this in with adding a queue to LOOK, which would trigger a Room.Item.List that could be processed for gold/shards.

Thoughts?