### PR TITLE
Prevent configuration loss while a user is browsing through the scrip…

### DIFF
--- a/Bashing.xml
+++ b/Bashing.xml
@@ -325,8 +325,8 @@ disableAlias(&quot;import from Guhem&quot;)</script>
 -- Note that you can also use external Scripts --
 -------------------------------------------------
 keneanung.bashing = keneanung.bashing or { }
-keneanung.bashing.configuration = {}
-keneanung.bashing.configuration.priorities = {}
+keneanung.bashing.configuration = keneanung.bashing.configuration or {}
+keneanung.bashing.configuration.priorities = keneanung.bashing.configuration.priorities or {}
 keneanung.bashing.targetList = {}</script>
                 <eventHandlerList/>
                 <Script isActive="yes" isFolder="no">


### PR DESCRIPTION
…ts in Mudlet.

Hi! I often lose configuration and target priorities for all areas when I'm just clicking through the script in Mudlet. This change prevents that from happening. No more hair pulling over having to hunt everywhere all over again! :grin: 