### PR TITLE
Use timeframes and cooldowns instead of gmcp.IRE.Display.ButtonActions

### DIFF
--- a/script.lua
+++ b/script.lua
@@ -1698,9 +1698,8 @@ keneanung.bashing.rageAvailable = function(ability)
 
 	if rage >= battlerageSkills[ability].rage then
 		return not keneanung.bashing.battlerageSkillsCD[ability]
-	else
-		return false
 	end
+	return false
 end
 
 keneanung.bashing.printGains = function(which)

--- a/script.lua
+++ b/script.lua
@@ -69,6 +69,7 @@ keneanung.bashing.configuration.priorities = {}
 keneanung.bashing.targetList = {}
 keneanung.bashing.systems = {}
 keneanung.bashing.battlerage = {}
+keneanung.bashing.battlerageSkillsCD = {} -- I couldn't get it to work as a local in a tempTimer D:
 keneanung.bashing.room = {}
 keneanung.bashing.pausingAfflictions = {}
 
@@ -454,6 +455,10 @@ end
 keneanung.bashing.battlerage.none = function(rage)
 end
 
+keneanung.bashing.battlerage.setCooldown = function(rage)
+	timeframe("keneanung.bashing.battlerageSkillsCD['"..rage.name.."']", 0, rage.cooldown)
+end
+
 keneanung.bashing.battlerage.simple = function(rage)
 	if keneanung.bashing.attacking == 0 then return end
 
@@ -469,12 +474,14 @@ keneanung.bashing.battlerage.simple = function(rage)
 	if not rageRazeFunction() then
 		if keneanung.bashing.rageAvailable(4) then
 			sendRageAttack(battlerageSkills[4].command)
+			keneanung.bashing.battlerage.setCooldown(battlerageSkills[4])
 		elseif
 			keneanung.bashing.rageAvailable(1) and
 				((not battlerageSkills[4].skillKnown) or
 				rage >= (battlerageSkills[1].rage + battlerageSkills[4].rage))
 		then
 			sendRageAttack(battlerageSkills[1].command)
+			keneanung.bashing.battlerage.setCooldown(battlerageSkills[1])
 		end
 	end
 end
@@ -494,8 +501,10 @@ keneanung.bashing.battlerage.simplereverse = function(rage)
 	if not rageRazeFunction() then
 		if keneanung.bashing.rageAvailable(1) then
 			sendRageAttack(battlerageSkills[1].command)
+			keneanung.bashing.battlerage.setCooldown(battlerageSkills[1])
 		elseif keneanung.bashing.rageAvailable(4) then
 			sendRageAttack(battlerageSkills[4].command)
+			keneanung.bashing.battlerage.setCooldown(battlerageSkills[4])
 		end
 	end
 end
@@ -1681,16 +1690,17 @@ keneanung.bashing.handleSkillInfo = function()
 end
 
 keneanung.bashing.rageAvailable = function(ability)
+
 	if keneanung.bashing.usedRageAttack then return false end
 	if type(ability) == "number" then
 		ability = battlerageSkills[ability].name
 	end
-	for _, button in pairs(gmcp.IRE.Display.ButtonActions) do
-		if button.text:lower() == ability:lower() then
-			return button.highlight == 1
-		end
+
+	if rage >= battlerageSkills[ability].rage then
+		return not keneanung.bashing.battlerageSkillsCD[ability]
+	else
+		return false
 	end
-	return false
 end
 
 keneanung.bashing.printGains = function(which)

--- a/script.lua
+++ b/script.lua
@@ -69,7 +69,7 @@ keneanung.bashing.configuration.priorities = {}
 keneanung.bashing.targetList = {}
 keneanung.bashing.systems = {}
 keneanung.bashing.battlerage = {}
-keneanung.bashing.battlerageSkillsCD = {} -- I couldn't get it to work as a local in a tempTimer D:
+keneanung.bashing.battlerageSkillsCD = {}
 keneanung.bashing.room = {}
 keneanung.bashing.pausingAfflictions = {}
 
@@ -156,16 +156,12 @@ end
 
 local startAttack = function()
 	local system = keneanung.bashing.systems[keneanung.bashing.configuration.system]
-        system.startAttack()
-	gmod.enableModule("keneanung.bashing", "IRE.Display")
-	sendGMCP([[Core.Supports.Add ["IRE.Display 3"] ]])   -- register the GMCP module independently from gmod.
+	system.startAttack()
 end
 
 local stopAttack = function()
 	local system = keneanung.bashing.systems[keneanung.bashing.configuration.system]
-        system.stopAttack()
-	gmod.disableModule("keneanung.bashing", "IRE.Display")
-	sendGMCP([[Core.Supports.Remove ["IRE.Display"] ]])   -- unregister the GMCP module independently from gmod.
+	system.stopAttack()
 end
 
 keneanung.bashing.systems.svo = {

--- a/script.lua
+++ b/script.lua
@@ -429,9 +429,10 @@ keneanung.bashing.systems.none = {
 
 }
 
-local function sendRageAttack(attack)
-	debugMessage("sending rage attack", attack)
-	send(attack:format(keneanung.bashing.targetList[keneanung.bashing.attacking].id), false)
+local function sendRageAttack(thisRage)
+	debugMessage("sending rage attack", thisRage.command)
+	send(thisRage.command:format(keneanung.bashing.targetList[keneanung.bashing.attacking].id), false)
+	keneanung.bashing.battlerage.setCooldown(thisRage)
 	keneanung.bashing.usedRageAttack = true
 	tempTimer(1, "keneanung.bashing.usedRageAttack = false")
 end
@@ -439,7 +440,7 @@ end
 local function rageRazeFunction()
 	if keneanung.bashing.shield then
 		if keneanung.bashing.configuration[class].autorageraze and keneanung.bashing.rageAvailable(3) then
-			send(battlerageSkills[3].command:format(keneanung.bashing.targetList[keneanung.bashing.attacking].id), false)
+			sendRageAttack(battlerageSkills[3])
 			keneanung.bashing.shield = false
 			local system = keneanung.bashing.systems[keneanung.bashing.configuration.system]
 			if system.brokeShield then
@@ -473,15 +474,13 @@ keneanung.bashing.battlerage.simple = function(rage)
 
 	if not rageRazeFunction() then
 		if keneanung.bashing.rageAvailable(4) then
-			sendRageAttack(battlerageSkills[4].command)
-			keneanung.bashing.battlerage.setCooldown(battlerageSkills[4])
+			sendRageAttack(battlerageSkills[4])
 		elseif
 			keneanung.bashing.rageAvailable(1) and
 				((not battlerageSkills[4].skillKnown) or
 				rage >= (battlerageSkills[1].rage + battlerageSkills[4].rage))
 		then
-			sendRageAttack(battlerageSkills[1].command)
-			keneanung.bashing.battlerage.setCooldown(battlerageSkills[1])
+			sendRageAttack(battlerageSkills[1])
 		end
 	end
 end
@@ -500,11 +499,9 @@ keneanung.bashing.battlerage.simplereverse = function(rage)
 
 	if not rageRazeFunction() then
 		if keneanung.bashing.rageAvailable(1) then
-			sendRageAttack(battlerageSkills[1].command)
-			keneanung.bashing.battlerage.setCooldown(battlerageSkills[1])
+			sendRageAttack(battlerageSkills[1])
 		elseif keneanung.bashing.rageAvailable(4) then
-			sendRageAttack(battlerageSkills[4].command)
-			keneanung.bashing.battlerage.setCooldown(battlerageSkills[4])
+			sendRageAttack(battlerageSkills[4])
 		end
 	end
 end


### PR DESCRIPTION
Hi! This pull request proposes using timeframes to manage battlerage cooldowns and removes the dependency on `gmcp.IRE.Display.ButtonActions` for us. Please let me know what you think!