### PR TITLE
Add network latency to battlerage cooldown timer

### DIFF
--- a/script.lua
+++ b/script.lua
@@ -453,7 +453,7 @@ keneanung.bashing.battlerage.none = function(rage)
 end
 
 keneanung.bashing.battlerage.setCooldown = function(rage)
-	timeframe("keneanung.bashing.battlerageSkillsCD['"..rage.name.."']", 0, rage.cooldown)
+	timeframe("keneanung.bashing.battlerageSkillsCD['"..rage.name.."']", 0, rage.cooldown + getNetworkLatency())
 end
 
 keneanung.bashing.battlerage.simple = function(rage)


### PR DESCRIPTION
Ahh, the pitfalls of client side timing! Sorry for the trouble :blush: This pull request adds network latency to our battlerage cooldown. This should fix 'You cannot use that ability again so soon.' if you're laggy and there's a difference between the rage actually going off and starting its cooldown timer with us.

On another note, I was looking around for what might make a battlerage not go through and perhaps possibly not raging if we had anything in proneAfflictions. But so far in my observation, battlerage attacks at not really hindered whatsoever. I'll keep a lookout for it and let you know if I find anything.