### PR TITLE
Adds a rate limiter to systems.none.startAttack()

### DIFF
--- a/script.lua
+++ b/script.lua
@@ -323,10 +323,24 @@ keneanung.bashing.systems.wundersys = {
 
 keneanung.bashing.systems.none = {
 
+	firstAttack = false,
+
 	startAttack = function()
+		timeframe("keneanung.bashing.systems.none.firstAttack", {0, true}, {1, false})
+		keneanung.bashing.systems.none.doAttack()
+	end,
+
+	doAttack = function()
 		if keneanung.bashing.attacking > 0 then
+
+			if keneanung.bashing.usedBalanceAttack and not keneanung.bashing.systems.none.firstAttack then
+				return true
+			end
+
 			enableTrigger(keneanung.bashing.systems.none.queueTrigger)
 			send("queue add eqbal keneanungki", false)
+
+			timeframe("keneanung.bashing.usedBalanceAttack", {0, true}, {0.5, false})
 		end
 	end,
 
@@ -388,7 +402,7 @@ keneanung.bashing.systems.none = {
 
 				end
 				if matches[2] == "KENEANUNGKI" then
-					send("queue add eqbal keneanungki", false)
+					keneanung.bashing.systems.none.doAttack()
 				else
 					keneanung.bashing.shield = false
 				end


### PR DESCRIPTION
Hi! This pull request adds a notion of rate limiting to the 'none' system when it comes to queueing the balance attack. It reuses `keneanung.bashing.usedBalanceAttack` to avoid duplicate queueing when we start seeing multiple `keneanung.bashing.systems.none.queueTrigger`s going off for any reason (mostly from `keneanung.bashing.afflictionCallback` here). To give a comparison:  

Before: https://ada-young.appspot.com/pastebin/Y53T9i4u
After: https://ada-young.appspot.com/pastebin/ZLlIObfQ  

No more full queues and lesser bouncing against denizen shields!