### PR TITLE
Check, if old target is still valid target

### DIFF
--- a/script.lua
+++ b/script.lua
@@ -109,22 +109,28 @@ keneanung.bashing.configuration.lifetimeGains = { gold = 0, experience = 0 }
 keneanung.bashing.configuration.manualTargetting = false
 keneanung.bashing.configuration.waitForManualTarget = 2
 
-local getTargetPrio = function(name)
-	local prios = keneanung.bashing.configuration.priorities[gmcp.Room.Info.area]
-
-	if not prios then
-		return
-	end
-
-	return table.index_of(prios, name)
-end
-
 local debugMessage = function(message, content)
 	if not debugEnabled then return end
 	echo(string.format("[%s]: %s", (debug.getinfo(2).name or "unknown"), message))
 	if content then
 		display(content)
 	end
+end
+
+local getTargetPrio = function(name)
+	local prios = keneanung.bashing.configuration.priorities[gmcp.Room.Info.area]
+
+        debugMessage("prios for this area", prios)
+
+	if not prios then
+		return
+	end
+
+        debugMessage("target name", name)
+
+	local prio = table.index_of(prios, name)
+        debugMessage("prio", prio)
+        return prio
 end
 
 local kecho = function(what, command, popup)
@@ -1139,9 +1145,7 @@ keneanung.bashing.addTarget = function(item)
 	local targets = keneanung.bashing.targetList
 	local insertAt
 
-	if not prios then
-		return
-	end
+        debugMessage("addTarget", item)
 
 	local targetPrio = getTargetPrio(item.name)
 

--- a/script.lua
+++ b/script.lua
@@ -116,7 +116,7 @@ local getTargetPrio = function(name)
 		return
 	end
 
-	return table.index_of(prios, item.name)
+	return table.index_of(prios, name)
 end
 
 local debugMessage = function(message, content)
@@ -1028,7 +1028,7 @@ local roomItemCallbackWorker = function(event)
 			-- make sure our targets stay at the same place!
 			for index, targ in ipairs(keneanung.bashing.targetList) do
 				-- still considered a target?
-				if getTargetPrio(targ) then
+				if getTargetPrio(targ.name) then
 					-- search if that target possibly left the room
 					local found = false
 					for _, item in ipairs(gmcp.Char.Items.List.items) do

--- a/script.lua
+++ b/script.lua
@@ -1028,7 +1028,7 @@ local roomItemCallbackWorker = function(event)
 			-- make sure our targets stay at the same place!
 			for index, targ in ipairs(keneanung.bashing.targetList) do
 				-- still considered a target?
-				if getTargetPrio(targ.name) then
+				if getTargetPrio(targ) then
 					-- search if that target possibly left the room
 					local found = false
 					for _, item in ipairs(gmcp.Char.Items.List.items) do


### PR DESCRIPTION
When restoring a target list from a room, check, whether the denizens there are still valid targets, before re-adding them.