### PR TITLE
Fix loading of script and version files

### DIFF
--- a/Bashing.xml
+++ b/Bashing.xml
@@ -420,7 +420,7 @@ end -- if
 local mod = getModulePath("Bashing")
 local dir
 if not mod or mod:ends('mpackage') then -- either package or installed via mpackage
-  dir = getMudletHomeDir() .. 'Bashing' .. _sep
+  dir = getMudletHomeDir() .. _sep .. 'Bashing' .. _sep
 else -- developer way
   dir = string.gsub(mod, "Bashing.xml", "")
 end

--- a/Bashing.xml
+++ b/Bashing.xml
@@ -417,14 +417,20 @@ else
 	_sep = "\\" 
 end -- if
 
-local dir = string.gsub(getModulePath("Bashing"), "Bashing.xml", "")
+local mod = getModulePath("Bashing")
+local dir
+if not mod or mod:ends('mpackage') then -- either package or installed via mpackage
+  dir = getMudletHomeDir() .. 'Bashing' .. _sep
+else -- developer way
+  dir = string.gsub(mod, "Bashing.xml", "")
+end
 
 echo(dir)
 
 local scriptFile = dir .. "script.lua"
 local versionFile = dir .. "version.lua"
 dofile(scriptFile)
-keneanung.bashing.version = dofile(versionFile)
+keneanung.bashing.version = io.exists(versionFile) and dofile(versionFile) or 'dev' -- version file does not exist for developer installs
 </script>
 					<eventHandlerList />
 				</Script>

--- a/Bashing.xml
+++ b/Bashing.xml
@@ -425,8 +425,6 @@ else -- developer way
   dir = string.gsub(mod, "Bashing.xml", "")
 end
 
-echo(dir)
-
 local scriptFile = dir .. "script.lua"
 local versionFile = dir .. "version.lua"
 dofile(scriptFile)


### PR DESCRIPTION
Changes to how the script file is loaded made the package unable to load the script file in every circumstance but dev setup. Now, all setups should be considered (package installations, module installations as mpackage, module installations as dev setup).

Fixes #87 