### PR TITLE
Don't send IH if SVO is installed

### DIFF
--- a/Bashing.xml
+++ b/Bashing.xml
@@ -377,7 +377,10 @@ disableAlias("import from Guhem")</script>
 				</Alias>
 				<Alias isActive="yes" isFolder="no">
 					<name>Check IH</name>
-					<script>send("ih")
+					<script>if not svo then
+  send("ih")
+end
+
 if not keneanung.bashing.configuration.enabled then return end
 
 keneanung.bashing.trackih = true</script>


### PR DESCRIPTION
This would be why IH worked before and didn't now - I had SVO installed at first, then didn't, and now do. So, let's make an exception!