### PR TITLE
Use the sysDataSendRequest for checking IH instead of alias

### DIFF
--- a/Bashing.xml
+++ b/Bashing.xml
@@ -375,19 +375,6 @@ disableAlias("import from Guhem")</script>
 					<packageName></packageName>
 					<regex>^kconfig bashing import$</regex>
 				</Alias>
-				<Alias isActive="yes" isFolder="no">
-					<name>Check IH</name>
-					<script>if not svo then
-  send("ih")
-end
-
-if not keneanung.bashing.configuration.enabled then return end
-
-keneanung.bashing.trackih = true</script>
-					<command></command>
-					<packageName></packageName>
-					<regex>^ih$</regex>
-				</Alias>
 			</AliasGroup>
 		</AliasGroup>
 	</AliasPackage>

--- a/script.lua
+++ b/script.lua
@@ -1198,6 +1198,10 @@ keneanung.bashing.sysDataSendRequestCallback = function(_, data)
   then
     sendGMCP('Core.Supports.Add ["IRE.Display 3"]')
   end
+
+  if lowerData:starts("ih") and keneanung.bashing.configuration.enabled then
+    keneanung.bashing.trackih = true
+  end
 end
 
 keneanung.bashing.emitEventsIfChanged = function( before, after)

--- a/script.lua
+++ b/script.lua
@@ -1199,7 +1199,7 @@ keneanung.bashing.sysDataSendRequestCallback = function(_, data)
     sendGMCP('Core.Supports.Add ["IRE.Display 3"]')
   end
 
-  if lowerData == "ih" and keneanung.bashing.configuration.enabled then
+  if (lowerData == "ih" or lowerData:starts("ih ")) and keneanung.bashing.configuration.enabled then
     keneanung.bashing.trackih = true
   end
 end
@@ -1210,7 +1210,6 @@ keneanung.bashing.emitEventsIfChanged = function( before, after)
     if before[1] ~= after[1] then
       raiseEvent("keneanung.bashing.targetList.firstChanged", after[1])
     end
-
   end
 end
 

--- a/script.lua
+++ b/script.lua
@@ -1199,7 +1199,7 @@ keneanung.bashing.sysDataSendRequestCallback = function(_, data)
     sendGMCP('Core.Supports.Add ["IRE.Display 3"]')
   end
 
-  if lowerData:starts("ih") and keneanung.bashing.configuration.enabled then
+  if lowerData == "ih" and keneanung.bashing.configuration.enabled then
     keneanung.bashing.trackih = true
   end
 end


### PR DESCRIPTION
Because SVO and other systems might alias IH for their own purposes, we should instead use the sysDataSendRequest and check to see if it starts with `ih ` or is `ih`. This should allow them to use the new feature without multiple commands of `ih` being sent, and piggy backs on pre-existing code.