### PR TITLE
Fix battlerage skill ordering and add dynamic skill list output

### DIFF
--- a/script.lua
+++ b/script.lua
@@ -154,6 +154,7 @@ local knownBattlerageSkillList = function()
     end
     return table.concat(names, " ")
   end
+
   return("processing... try doing some things!")
 end
 
@@ -167,8 +168,8 @@ local sortDepthswalkerBattlerage = function()
 
   debugMessage("sorting brage for walkers", {battlerageSkills = battlerageSkills})
 
-  if class ~= "Depthswalker" or #battlerageSkills ~= 7 then return end
-  battlerageSkills[3], battlerageSkills[4], battlerageSkills[5] = battlerageSkills["curse"], battlerageSkills["nakail"], battlerageSkills["lash"]
+  if class ~= "Depthswalker" or #battlerageSkills ~= 6 then return end
+  battlerageSkills[2], battlerageSkills[3], battlerageSkills[4] = battlerageSkills["curse"], battlerageSkills["nakail"], battlerageSkills["lash"]
 
   battlerageSkills["curse"].affliction = "aeon"
   battlerageSkills["boinad"].affliction = "charm"
@@ -185,8 +186,8 @@ local sortPariahBattlerage = function()
 
   debugMessage("sorting brage for pariah", {battlerageSkills = battlerageSkills})
 
-  if class ~= "Pariah" or #battlerageSkills ~= 7 then return end
-  battlerageSkills[3], battlerageSkills[4], battlerageSkills[5] = battlerageSkills["symphony"], battlerageSkills["scour"], battlerageSkills["feast"]
+  if class ~= "Pariah" or #battlerageSkills ~= 6 then return end
+  battlerageSkills[2], battlerageSkills[3], battlerageSkills[4] = battlerageSkills["symphony"], battlerageSkills["scour"], battlerageSkills["feast"]
 
   battlerageSkills["symphony"].affliction = "fear"
   battlerageSkills["wail"].affliction = "clumsiness"
@@ -206,8 +207,8 @@ local sortPsionBattlerage = function()
 
   debugMessage("sorting brage for psion", {battlerageSkills = battlerageSkills})
 
-  if class ~= "Psion" or #battlerageSkills ~= 7 then return end
-  battlerageSkills[3], battlerageSkills[4], battlerageSkills[5] = battlerageSkills["regrowth"], battlerageSkills["pulverise"], battlerageSkills["devastate"]
+  if class ~= "Psion" or #battlerageSkills ~= 6 then return end
+  battlerageSkills[2], battlerageSkills[3], battlerageSkills[4] = battlerageSkills["regrowth"], battlerageSkills["pulverise"], battlerageSkills["devastate"]
 
   battlerageSkills["terror"].affliction = "fear"
 
@@ -219,8 +220,8 @@ local sortUnnamableBattlerage = function()
 
   debugMessage("sorting brage for unnamable", {battlerageSkills = battlerageSkills})
 
-  if class ~= "Unnamable" or #battlerageSkills ~= 7 then return end
-  battlerageSkills[3], battlerageSkills[4], battlerageSkills[5] = battlerageSkills["dread"], battlerageSkills["sunder"], battlerageSkills["destroy"]
+  if class ~= "Unnamable" or #battlerageSkills ~= 6 then return end
+  battlerageSkills[2], battlerageSkills[3], battlerageSkills[4] = battlerageSkills["dread"], battlerageSkills["sunder"], battlerageSkills["destroy"]
 
   battlerageSkills["dread"].affliction = "fear"
   battlerageSkills["entropy"].affliction = "aeon"
@@ -231,6 +232,14 @@ local sortUnnamableBattlerage = function()
   }
 
   debugMessage("sorted brage for unnamable", {battlerageSkills = battlerageSkills})
+end
+
+local sortProvokeBattlerage = function()
+  if battlerageSkills[1] and battlerageSkills[1].name:lower() == "provoke" then
+    local provoke = table.remove(battlerageSkills, 1)
+    table.insert(battlerageSkills, provoke)
+    debugMessage("Moved provoke to end of battlerageSkills", battlerageSkills)
+  end
 end
 
 local requestAllSkillDetails = function()
@@ -561,8 +570,8 @@ end
 
 local function rageRazeFunction()
   if keneanung.bashing.shield then
-    if keneanung.bashing.configuration[class].autorageraze and keneanung.bashing.rageAvailable(4) then
-      send(battlerageSkills[4].command:format(keneanung.bashing.targetList[keneanung.bashing.attacking].id), false)
+    if keneanung.bashing.configuration[class].autorageraze and keneanung.bashing.rageAvailable(3) then
+      send(battlerageSkills[3].command:format(keneanung.bashing.targetList[keneanung.bashing.attacking].id), false)
       keneanung.bashing.shield = false
       local system = keneanung.bashing.systems[keneanung.bashing.configuration.system]
       if system.brokeShield then
@@ -591,14 +600,14 @@ keneanung.bashing.battlerage.simple = function(rage)
   )
 
   if not rageRazeFunction() then
-    if keneanung.bashing.rageAvailable(5) then
-      sendRageAttack(battlerageSkills[5].command)
+    if keneanung.bashing.rageAvailable(4) then
+      sendRageAttack(battlerageSkills[4].command)
     elseif
-      keneanung.bashing.rageAvailable(2) and
-        ((not battlerageSkills[5].skillKnown) or
-        rage >= (battlerageSkills[2].rage + battlerageSkills[5].rage))
+      keneanung.bashing.rageAvailable(1) and
+        ((not battlerageSkills[4].skillKnown) or
+        rage >= (battlerageSkills[1].rage + battlerageSkills[4].rage))
     then
-      sendRageAttack(battlerageSkills[2].command)
+      sendRageAttack(battlerageSkills[1].command)
     end
   end
 end
@@ -616,10 +625,10 @@ keneanung.bashing.battlerage.simplereverse = function(rage)
   )
 
   if not rageRazeFunction() then
-    if keneanung.bashing.rageAvailable(2) then
-      sendRageAttack(battlerageSkills[2].command)
-    elseif keneanung.bashing.rageAvailable(5) then
-      sendRageAttack(battlerageSkills[5].command)
+    if keneanung.bashing.rageAvailable(1) then
+      sendRageAttack(battlerageSkills[1].command)
+    elseif keneanung.bashing.rageAvailable(4) then
+      sendRageAttack(battlerageSkills[4].command)
     end
   end
 end
@@ -1869,6 +1878,7 @@ keneanung.bashing.handleSkillInfo = function()
         sortPariahBattlerage()
         sortPsionBattlerage()
         sortUnnamableBattlerage()
+		sortProvokeBattlerage()
         kecho("Finished parsing battlerage skills.\n")
       end
     end

--- a/script.lua
+++ b/script.lua
@@ -169,7 +169,7 @@ local sortDepthswalkerBattlerage = function()
 
   debugMessage("sorting brage for walkers", {battlerageSkills = battlerageSkills})
 
-  if class ~= "Depthswalker" or #battlerageSkills ~= 6 then return end
+  if class ~= "Depthswalker" or #battlerageSkills ~= EXPECTED_BATTLERAGE_COUNT then return end
   battlerageSkills[2], battlerageSkills[3], battlerageSkills[4] = battlerageSkills["curse"], battlerageSkills["nakail"], battlerageSkills["lash"]
 
   battlerageSkills["curse"].affliction = "aeon"

--- a/script.lua
+++ b/script.lua
@@ -148,7 +148,11 @@ end
 
 local knownBattlerageSkillList = function()
   if #requestSkillDetails == 0 then
-    return battlerageSkills[1].name .. " " .. battlerageSkills[2].name .. " " .. battlerageSkills[3].name .. " ".. battlerageSkills[4].name .. " ".. battlerageSkills[5].name .. " ".. battlerageSkills[6].name
+    local names = {}
+    for i, skill in ipairs(battlerageSkills) do
+      names[#names+1] = skill.name
+    end
+    return table.concat(names, " ")
   end
   return("processing... try doing some things!")
 end
@@ -163,8 +167,8 @@ local sortDepthswalkerBattlerage = function()
 
   debugMessage("sorting brage for walkers", {battlerageSkills = battlerageSkills})
 
-  if class ~= "Depthswalker" or #battlerageSkills ~= 6 then return end
-  battlerageSkills[2], battlerageSkills[3], battlerageSkills[4] = battlerageSkills["curse"], battlerageSkills["nakail"], battlerageSkills["lash"]
+  if class ~= "Depthswalker" or #battlerageSkills ~= 7 then return end
+  battlerageSkills[3], battlerageSkills[4], battlerageSkills[5] = battlerageSkills["curse"], battlerageSkills["nakail"], battlerageSkills["lash"]
 
   battlerageSkills["curse"].affliction = "aeon"
   battlerageSkills["boinad"].affliction = "charm"
@@ -181,8 +185,8 @@ local sortPariahBattlerage = function()
 
   debugMessage("sorting brage for pariah", {battlerageSkills = battlerageSkills})
 
-  if class ~= "Pariah" or #battlerageSkills ~= 6 then return end
-  battlerageSkills[2], battlerageSkills[3], battlerageSkills[4] = battlerageSkills["symphony"], battlerageSkills["scour"], battlerageSkills["feast"]
+  if class ~= "Pariah" or #battlerageSkills ~= 7 then return end
+  battlerageSkills[3], battlerageSkills[4], battlerageSkills[5] = battlerageSkills["symphony"], battlerageSkills["scour"], battlerageSkills["feast"]
 
   battlerageSkills["symphony"].affliction = "fear"
   battlerageSkills["wail"].affliction = "clumsiness"
@@ -202,8 +206,8 @@ local sortPsionBattlerage = function()
 
   debugMessage("sorting brage for psion", {battlerageSkills = battlerageSkills})
 
-  if class ~= "Psion" or #battlerageSkills ~= 6 then return end
-  battlerageSkills[2], battlerageSkills[3], battlerageSkills[4] = battlerageSkills["regrowth"], battlerageSkills["pulverise"], battlerageSkills["devastate"]
+  if class ~= "Psion" or #battlerageSkills ~= 7 then return end
+  battlerageSkills[3], battlerageSkills[4], battlerageSkills[5] = battlerageSkills["regrowth"], battlerageSkills["pulverise"], battlerageSkills["devastate"]
 
   battlerageSkills["terror"].affliction = "fear"
 
@@ -215,8 +219,8 @@ local sortUnnamableBattlerage = function()
 
   debugMessage("sorting brage for unnamable", {battlerageSkills = battlerageSkills})
 
-  if class ~= "Unnamable" or #battlerageSkills ~= 6 then return end
-  battlerageSkills[2], battlerageSkills[3], battlerageSkills[4] = battlerageSkills["dread"], battlerageSkills["sunder"], battlerageSkills["destroy"]
+  if class ~= "Unnamable" or #battlerageSkills ~= 7 then return end
+  battlerageSkills[3], battlerageSkills[4], battlerageSkills[5] = battlerageSkills["dread"], battlerageSkills["sunder"], battlerageSkills["destroy"]
 
   battlerageSkills["dread"].affliction = "fear"
   battlerageSkills["entropy"].affliction = "aeon"
@@ -557,8 +561,8 @@ end
 
 local function rageRazeFunction()
   if keneanung.bashing.shield then
-    if keneanung.bashing.configuration[class].autorageraze and keneanung.bashing.rageAvailable(3) then
-      send(battlerageSkills[3].command:format(keneanung.bashing.targetList[keneanung.bashing.attacking].id), false)
+    if keneanung.bashing.configuration[class].autorageraze and keneanung.bashing.rageAvailable(4) then
+      send(battlerageSkills[4].command:format(keneanung.bashing.targetList[keneanung.bashing.attacking].id), false)
       keneanung.bashing.shield = false
       local system = keneanung.bashing.systems[keneanung.bashing.configuration.system]
       if system.brokeShield then
@@ -587,14 +591,14 @@ keneanung.bashing.battlerage.simple = function(rage)
   )
 
   if not rageRazeFunction() then
-    if keneanung.bashing.rageAvailable(4) then
-      sendRageAttack(battlerageSkills[4].command)
+    if keneanung.bashing.rageAvailable(5) then
+      sendRageAttack(battlerageSkills[5].command)
     elseif
-      keneanung.bashing.rageAvailable(1) and
-        ((not battlerageSkills[4].skillKnown) or
-        rage >= (battlerageSkills[1].rage + battlerageSkills[4].rage))
+      keneanung.bashing.rageAvailable(2) and
+        ((not battlerageSkills[5].skillKnown) or
+        rage >= (battlerageSkills[2].rage + battlerageSkills[5].rage))
     then
-      sendRageAttack(battlerageSkills[1].command)
+      sendRageAttack(battlerageSkills[2].command)
     end
   end
 end
@@ -612,10 +616,10 @@ keneanung.bashing.battlerage.simplereverse = function(rage)
   )
 
   if not rageRazeFunction() then
-    if keneanung.bashing.rageAvailable(1) then
-      sendRageAttack(battlerageSkills[1].command)
-    elseif keneanung.bashing.rageAvailable(4) then
-      sendRageAttack(battlerageSkills[4].command)
+    if keneanung.bashing.rageAvailable(2) then
+      sendRageAttack(battlerageSkills[2].command)
+    elseif keneanung.bashing.rageAvailable(5) then
+      sendRageAttack(battlerageSkills[5].command)
     end
   end
 end

--- a/script.lua
+++ b/script.lua
@@ -1873,7 +1873,7 @@ keneanung.bashing.handleSkillInfo = function()
       battlerageSkills[skillInfo.skill] = rageObject
       battlerageSkills[#battlerageSkills + 1] = rageObject
       debugMessage("added new battlerage skill complete list is here ", battlerageSkills)
-      if #battlerageSkills == 6 then
+      if #battlerageSkills == 7 then
         sortDepthswalkerBattlerage()
         sortPariahBattlerage()
         sortPsionBattlerage()

--- a/script.lua
+++ b/script.lua
@@ -79,6 +79,7 @@ local denizenCache = {}
 
 local waitingForManualTargetTimer
 local waitingForManualTarget = false
+local EXPECTED_BATTLERAGE_COUNT = 7
 
 keneanung = keneanung or {}
 keneanung.bashing = {}
@@ -186,7 +187,7 @@ local sortPariahBattlerage = function()
 
   debugMessage("sorting brage for pariah", {battlerageSkills = battlerageSkills})
 
-  if class ~= "Pariah" or #battlerageSkills ~= 6 then return end
+  if class ~= "Pariah" or #battlerageSkills ~= EXPECTED_BATTLERAGE_COUNT then return end
   battlerageSkills[2], battlerageSkills[3], battlerageSkills[4] = battlerageSkills["symphony"], battlerageSkills["scour"], battlerageSkills["feast"]
 
   battlerageSkills["symphony"].affliction = "fear"
@@ -207,7 +208,7 @@ local sortPsionBattlerage = function()
 
   debugMessage("sorting brage for psion", {battlerageSkills = battlerageSkills})
 
-  if class ~= "Psion" or #battlerageSkills ~= 6 then return end
+  if class ~= "Psion" or #battlerageSkills ~= EXPECTED_BATTLERAGE_COUNT then return end
   battlerageSkills[2], battlerageSkills[3], battlerageSkills[4] = battlerageSkills["regrowth"], battlerageSkills["pulverise"], battlerageSkills["devastate"]
 
   battlerageSkills["terror"].affliction = "fear"
@@ -220,7 +221,7 @@ local sortUnnamableBattlerage = function()
 
   debugMessage("sorting brage for unnamable", {battlerageSkills = battlerageSkills})
 
-  if class ~= "Unnamable" or #battlerageSkills ~= 6 then return end
+  if class ~= "Unnamable" or #battlerageSkills ~= EXPECTED_BATTLERAGE_COUNT then return end
   battlerageSkills[2], battlerageSkills[3], battlerageSkills[4] = battlerageSkills["dread"], battlerageSkills["sunder"], battlerageSkills["destroy"]
 
   battlerageSkills["dread"].affliction = "fear"
@@ -1873,14 +1874,14 @@ keneanung.bashing.handleSkillInfo = function()
       battlerageSkills[skillInfo.skill] = rageObject
       battlerageSkills[#battlerageSkills + 1] = rageObject
       debugMessage("added new battlerage skill complete list is here ", battlerageSkills)
-      if #battlerageSkills == 7 then
-        sortDepthswalkerBattlerage()
-        sortPariahBattlerage()
-        sortPsionBattlerage()
-        sortUnnamableBattlerage()
-		sortProvokeBattlerage()
-        kecho("Finished parsing battlerage skills.\n")
-      end
+		 if #battlerageSkills >= EXPECTED_BATTLERAGE_COUNT then
+		  sortProvokeBattlerage() -- Must go first to fix ordering
+		  sortDepthswalkerBattlerage()
+		  sortPariahBattlerage()
+		  sortPsionBattlerage()
+		  sortUnnamableBattlerage()
+		  kecho("Finished parsing battlerage skills.\n")
+		end
     end
   else
     debugMessage("got double battlerage skill")


### PR DESCRIPTION
Achaea's recent update added a new battlerage skill (e.g., provoke) that now appears first in the skill list via GMCP. This breaks existing logic that expects skill positions to remain unchanged.
Changes:
Added sortProvokeBattlerage() to detect when provoke is the first skill and move it to the end of battlerageSkills.
Called sortProvokeBattlerage() after all class-specific sorting functions.
Rewrote knownBattlerageSkillList() to dynamically list all known battlerage skill names, future-proofing the output.
This avoids the need to change all index references and preserves compatibility with current battlerage strategies.